### PR TITLE
Name Query Fix (GET & Sync)

### DIFF
--- a/routes/instances.js
+++ b/routes/instances.js
@@ -71,9 +71,11 @@ router.get('/', function(req, res, next) {
  */
 router.get('/:id', function(req, res, next) {
     var toFind = req.params.id;
+
+    var regex = new RegExp(["^", toFind, "$"].join(""), "i");
     // Exec query
     Instance.find({
-        $or:[ { id: toFind}, {name: {$regex: toFind, $options: "i"}} ]  // Case Insensitive
+        $or:[ { id: toFind}, {name: regex } ]  // Case Insensitive
     }, function(err, instances){
         if (err){
             return res.send(err);

--- a/routes/synchronize.js
+++ b/routes/synchronize.js
@@ -18,8 +18,9 @@ var Instance = require('../models/instance');
 router.put('/:id', passport.authenticate('basic', {session: false}), function(req, res, next){
     var toFind = req.params.id;
     // Find the instance to update
+    var regex = new RegExp(["^", toFind, "$"].join(""), "i");
     Instance.findOne({
-        $or:[ { id: toFind}, {name: {$regex: toFind, $options: "i"}} ]
+        $or:[ { id: toFind}, {name: regex} ]
     }, function(err, instance){
       // Instance not found
       if (instance == null){


### PR DESCRIPTION
Fixed: When you want to get one instance, the Mongo query search for substrings in the mine name. Causing problems when instances have similar name. E.g. Flymine and Flymine Beta. 