### PR TITLE
Enable CORS so other webapps can load from the registry

### DIFF
--- a/app.js
+++ b/app.js
@@ -46,6 +46,13 @@ app.use(express.static(__dirname + '/node_modules/bootstrap-material-design/dist
 app.use('/images', express.static(__dirname + '/node_modules/leaflet-search/images'));
 app.use(express.static(__dirname + '/node_modules/leaflet-search/dist'));
 
+//enable CORS
+app.use(function(req, res, next) {
+  res.header("Access-Control-Allow-Origin", "*");
+  res.header("Access-Control-Allow-Headers", "Origin, X-Requested-With, Content-Type, Accept");
+  next();
+});
+
 //Routes
 app.use('/api-docs', swaggerUi.serve, swaggerUi.setup(swaggerDocument));
 app.use('/', index);


### PR DESCRIPTION
Sets the correct headers to allow browser-based cross-origin requests. Fix for: https://github.com/intermine/intermine/issues/1723#issuecomment-347624028

To test: set the url of the registry or test registry in this jsbin: http://jsbin.com/moxined/edit?js,console

it should print an error or success message to the console based on whether or not cors is enabled