### PR TITLE
don't try to init map if there are no lat/long coords

### DIFF
--- a/public/javascripts/map.js
+++ b/public/javascripts/map.js
@@ -31,7 +31,9 @@ function loadMines(){
         }
       }
     }
-    mineMiner().init();
+    if (mines.length > 0) {
+      mineMiner().init();
+    }
   });
 }
 


### PR DESCRIPTION
this prevents errors on newly initialised registry projects. 