### PR TITLE
Added return InterMines over a given version

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,8 +3,8 @@
   "version": "0.0.0",
   "private": true,
   "repository": {
-  "type": "git",
-  "url": "https://github.com/intermine/intermine-registry"
+    "type": "git",
+    "url": "https://github.com/intermine/intermine-registry"
   },
   "scripts": {
     "start": "node ./bin/www"

--- a/routes/instances.js
+++ b/routes/instances.js
@@ -597,16 +597,17 @@ function filterBySemanticVersions(condition, givenVersion) {
         const pg = givenVersion.split('.')[i];
         
         try {
-            if (!op(parseInt(pg, 10), parseInt(pc, 10)))
-                return false;
-            else
-                continue;
+            if (op(parseInt(pg, 10), parseInt(pc, 10)))
+                return true;
+            else if (parseInt(pg, 10) == parseInt(pc, 10))
+                continue;                
         } catch (error) {
             console.error('Invalid semantic verison', error);
-            return false;
+            break;
         }
     }
-    return true;
+    // By default, return false or if exception
+    return false;
 }
 
 function stringOpToFunction(op) {

--- a/routes/instances.js
+++ b/routes/instances.js
@@ -596,10 +596,15 @@ function filterBySemanticVersions(condition, givenVersion) {
     for (const [i, pc] of reqVersion.split('.').entries()) {
         const pg = givenVersion.split('.')[i];
         
-        if (!op(parseInt(pg, 10), parseInt(pc, 10)))
+        try {
+            if (!op(parseInt(pg, 10), parseInt(pc, 10)))
+                return false;
+            else
+                continue;
+        } catch (error) {
+            console.error('Invalid semantic verison', error);
             return false;
-        else
-            continue;
+        }
     }
     return true;
 }

--- a/routes/instances.js
+++ b/routes/instances.js
@@ -595,12 +595,17 @@ function filterBySemanticVersions(condition, givenVersion) {
 
     for (const [i, pc] of reqVersion.split('.').entries()) {
         const pg = givenVersion.split('.')[i];
+
+        // If condition version has token 'x' (for any), skip this token
+        if (pc === 'x') continue;
         
         try {
-            if (op(parseInt(pg, 10), parseInt(pc, 10)))
+            if (parseInt(pg, 10) == parseInt(pc, 10))
+                continue;
+            else if (op(parseInt(pg, 10), parseInt(pc, 10)))
                 return true;
-            else if (parseInt(pg, 10) == parseInt(pc, 10))
-                continue;                
+            else
+                break;
         } catch (error) {
             console.error('Invalid semantic verison', error);
             break;


### PR DESCRIPTION
As suggested in issue #130, **added code to filter InterMines by semantic versions** and return only those which match the given condition. Implemented according to [this.](https://github.com/intermine/intermine-registry/issues/130#issue-478931146)

## Useage
There are 5 condition operators which are
```
gt (greater than)
gte (greater than or equal to)
lt (less than)
lte (less than or equal to)
eq (equal to)
```

These are sent with the desired version as follows
```
GET    http://registry.intermine.org/service/instances?version_api=gte-24
GET    http://registry.intermine.org/service/instances?version_intermine=lt-2.5.23
```

## Caveats
The following things are desired but aren't implemented yet
- Doesn't yet support `alpha`,`beta` etc. in semantic versions (eg: 4.4.12-alpha)
- Doesn't yet support ranges, although that wouldn't need too much modification